### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,8 @@ on:
   pull_request:
 
 name: Lint
+permissions:
+  contents: read
 
 jobs:
   lint:


### PR DESCRIPTION
Potential fix for [https://github.com/Open-Systems-Pharmacology/OSPSuite.Plots/security/code-scanning/1](https://github.com/Open-Systems-Pharmacology/OSPSuite.Plots/security/code-scanning/1)

To fix the issue, add a `permissions:` block at the root of the workflow file (above or just below `jobs:`), setting `contents: read` as the only permission. This ensures the GITHUB_TOKEN used in this workflow cannot write to the repository or take unnecessary privileged actions. No changes to existing workflow steps are required because none need write permissions. Edits should be introduced at the top level of `.github/workflows/lint.yaml`, ideally after the `name:` field and before or after the `on:` field (per YAML syntax), but before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
