### PR TITLE
Restore original shape order with improved visual distinction

### DIFF
--- a/R/utilities_shapes.R
+++ b/R/utilities_shapes.R
@@ -2,29 +2,29 @@
 #' @description Character vector of all available OSP shape names.
 #' @export
 ospShapeNames <- c(
-  # Filled shapes first (for distinct visual differentiation)
   "circle",
   "diamond",
-  "square",
   "triangle",
+  "square",
   "invertedTriangle",
+  "cross",
+  "plus",
+  "asterisk",
+  "star",
   "pentagon",
   "hexagon",
-  "star",
-  "plus",
-  "cross",
-  "asterisk",
+  # Thin shapes
+  "thinCross",
+  "thinPlus",
   # Open shapes
   "circleOpen",
   "diamondOpen",
-  "squareOpen",
   "triangleOpen",
+  "squareOpen",
   "invertedTriangleOpen",
+  "starOpen",
   "pentagonOpen",
   "hexagonOpen",
-  "starOpen",
-  "thinPlus",
-  "thinCross",
   "blank"
 )
 
@@ -76,18 +76,82 @@ Shapes <- stats::setNames(as.list(ospShapeNames), ospShapeNames)
 .ospShapeSpec <- list(
   circle = list(kind = "polygon", n = 64, angle = 0, open = FALSE),
   circleOpen = list(kind = "polygon", n = 64, angle = 0, open = TRUE),
-  square = list(kind = "polygon", n = 4, angle = 45, open = FALSE, scale = 1.41),
-  squareOpen = list(kind = "polygon", n = 4, angle = 45, open = TRUE, scale = 1.41),
+  square = list(
+    kind = "polygon",
+    n = 4,
+    angle = 45,
+    open = FALSE,
+    scale = 1.41
+  ),
+  squareOpen = list(
+    kind = "polygon",
+    n = 4,
+    angle = 45,
+    open = TRUE,
+    scale = 1.41
+  ),
   diamond = list(kind = "polygon", n = 4, angle = 0, open = FALSE),
   diamondOpen = list(kind = "polygon", n = 4, angle = 0, open = TRUE),
-  triangle = list(kind = "polygon", n = 3, angle = 90, open = FALSE, scale = 1.23, yOffset = -0.25),
-  triangleOpen = list(kind = "polygon", n = 3, angle = 90, open = TRUE, scale = 1.23, yOffset = -0.25),
-  invertedTriangle = list(kind = "polygon", n = 3, angle = -90, open = FALSE, scale = 1.23, yOffset = 0.25),
-  invertedTriangleOpen = list(kind = "polygon", n = 3, angle = -90, open = TRUE, scale = 1.23, yOffset = 0.25),
-  pentagon = list(kind = "polygon", n = 5, angle = 90, open = FALSE, scale = 1.08),
-  pentagonOpen = list(kind = "polygon", n = 5, angle = 90, open = TRUE, scale = 1.08),
-  hexagon = list(kind = "polygon", n = 6, angle = 90, open = FALSE, scale = 1.07),
-  hexagonOpen = list(kind = "polygon", n = 6, angle = 90, open = TRUE, scale = 1.07),
+  triangle = list(
+    kind = "polygon",
+    n = 3,
+    angle = 90,
+    open = FALSE,
+    scale = 1.23,
+    yOffset = -0.25
+  ),
+  triangleOpen = list(
+    kind = "polygon",
+    n = 3,
+    angle = 90,
+    open = TRUE,
+    scale = 1.23,
+    yOffset = -0.25
+  ),
+  invertedTriangle = list(
+    kind = "polygon",
+    n = 3,
+    angle = -90,
+    open = FALSE,
+    scale = 1.23,
+    yOffset = 0.25
+  ),
+  invertedTriangleOpen = list(
+    kind = "polygon",
+    n = 3,
+    angle = -90,
+    open = TRUE,
+    scale = 1.23,
+    yOffset = 0.25
+  ),
+  pentagon = list(
+    kind = "polygon",
+    n = 5,
+    angle = 90,
+    open = FALSE,
+    scale = 1.08
+  ),
+  pentagonOpen = list(
+    kind = "polygon",
+    n = 5,
+    angle = 90,
+    open = TRUE,
+    scale = 1.08
+  ),
+  hexagon = list(
+    kind = "polygon",
+    n = 6,
+    angle = 90,
+    open = FALSE,
+    scale = 1.07
+  ),
+  hexagonOpen = list(
+    kind = "polygon",
+    n = 6,
+    angle = 90,
+    open = TRUE,
+    scale = 1.07
+  ),
   star = list(kind = "star", points = 5, open = FALSE, scale = 1.08),
   starOpen = list(kind = "star", points = 5, open = TRUE, scale = 1.08),
   plus = list(kind = "stroke", glyph = "plus", thick = TRUE),
@@ -153,7 +217,12 @@ Shapes <- stats::setNames(as.list(ospShapeNames), ospShapeNames)
     stroke = {
       # Thick strokes (plus, cross, asterisk) need heavier weight for visibility
       lwd <- if (isTRUE(spec$thick)) strokeLwd * 2.2 else strokeLwd
-      gpStroke <- grid::gpar(col = colour, lwd = lwd, alpha = alpha, lineend = "butt")
+      gpStroke <- grid::gpar(
+        col = colour,
+        lwd = lwd,
+        alpha = alpha,
+        lineend = "butt"
+      )
       switch(
         spec$glyph,
         plus = grid::segmentsGrob(
@@ -217,7 +286,8 @@ GeomPointOsp <- ggplot2::ggproto(
     unknownShapes <- setdiff(unique(as.character(coords$shape)), ospShapeNames)
     if (length(unknownShapes) > 0) {
       warning(
-        "Unknown shape(s): ", paste(shQuote(unknownShapes), collapse = ", "),
+        "Unknown shape(s): ",
+        paste(shQuote(unknownShapes), collapse = ", "),
         ". Using 'circle' instead.",
         call. = FALSE
       )
@@ -360,7 +430,11 @@ scale_shape_osp <- function(...) {
   nShapes <- length(visibleShapes)
   if (n > nShapes) {
     warning(
-      "Number of groups (", n, ") exceeds available shapes (", nShapes, "). ",
+      "Number of groups (",
+      n,
+      ") exceeds available shapes (",
+      nShapes,
+      "). ",
       "Shapes will be recycled.",
       call. = FALSE
     )
@@ -420,4 +494,3 @@ scale_shape_osp_identity <- function(guide = "none", ...) {
   values <- stats::setNames(ospShapeNames, ospShapeNames)
   ggplot2::scale_shape_manual(values = values, guide = guide, ...)
 }
-

--- a/tests/testthat/_snaps/plotYVsX/plotratiovscov.svg
+++ b/tests/testthat/_snaps/plotYVsX/plotratiovscov.svg
@@ -36,16 +36,18 @@
 <polyline points='77.23,111.17 82.49,112.93 87.74,114.74 93.00,116.61 98.25,118.53 103.51,120.51 108.76,122.55 114.02,124.66 119.27,126.83 124.53,129.07 129.78,131.38 135.04,133.76 140.29,136.22 145.55,138.75 150.80,141.37 156.06,144.08 161.31,146.87 166.57,149.76 171.82,152.75 177.08,155.83 182.33,159.02 187.59,162.32 192.84,165.74 198.10,169.27 203.35,172.93 208.61,176.72 213.86,180.65 219.12,184.73 224.37,188.95 229.63,193.34 234.88,197.89 240.14,202.62 245.39,207.53 250.65,212.64 255.90,217.95 261.16,216.61 266.41,211.34 271.67,206.28 276.92,201.42 282.18,196.73 287.43,192.23 292.69,187.88 297.95,183.69 303.20,179.66 308.46,175.76 313.71,172.00 318.97,168.38 324.22,164.87 329.48,161.49 334.73,158.21 339.99,155.05 345.24,151.99 350.50,149.03 355.75,146.17 361.01,143.40 366.26,140.71 371.52,138.11 376.77,135.60 382.03,133.16 387.28,130.79 392.54,128.50 397.79,126.28 403.05,124.13 408.30,122.04 413.56,120.01 418.81,118.04 424.07,116.13 429.32,114.28 434.58,112.48 439.83,110.74 445.09,109.04 450.34,107.40 455.60,105.80 460.85,104.24 466.11,102.73 471.36,101.27 476.62,99.84 481.87,98.46 487.13,97.11 492.38,95.80 497.64,94.53 502.89,93.29 508.15,92.08 513.40,90.91 518.66,89.77 523.91,88.67 529.17,87.59 534.42,86.54 539.68,85.52 544.93,84.53 550.19,83.56 555.44,82.62 560.70,81.71 565.96,80.81 571.21,79.95 576.47,79.10 581.72,78.28 586.98,77.48 592.23,76.70 597.49,75.94 602.74,75.20 ' style='stroke-width: 1.07; stroke-dasharray: 5.69,5.69; stroke-linecap: butt;' />
 <polygon points='124.41,429.64 124.40,429.45 124.37,429.26 124.32,429.07 124.26,428.89 124.18,428.72 124.08,428.55 123.96,428.40 123.83,428.25 123.69,428.13 123.54,428.01 123.37,427.91 123.20,427.83 123.02,427.77 122.83,427.72 122.64,427.69 122.45,427.68 122.26,427.69 122.07,427.72 121.88,427.77 121.70,427.83 121.53,427.91 121.36,428.01 121.21,428.13 121.07,428.25 120.94,428.40 120.82,428.55 120.73,428.72 120.64,428.89 120.58,429.07 120.53,429.26 120.50,429.45 120.49,429.64 120.50,429.83 120.53,430.02 120.58,430.21 120.64,430.39 120.73,430.56 120.82,430.72 120.94,430.88 121.07,431.02 121.21,431.15 121.36,431.26 121.53,431.36 121.70,431.44 121.88,431.51 122.07,431.56 122.26,431.58 122.45,431.59 122.64,431.58 122.83,431.56 123.02,431.51 123.20,431.44 123.37,431.36 123.54,431.26 123.69,431.15 123.83,431.02 123.96,430.88 124.08,430.72 124.18,430.56 124.26,430.39 124.32,430.21 124.37,430.02 124.40,429.83 ' style='stroke-width: 0.71; stroke: #5050FF; fill: #5050FF;' />
 <polygon points='299.53,184.15 297.58,182.19 295.62,184.15 297.58,186.10 ' style='stroke-width: 0.71; stroke: #CE3D32; fill: #CE3D32;' />
-<polygon points='79.18,331.53 75.28,331.53 75.28,335.43 79.18,335.43 ' style='stroke-width: 0.71; stroke: #749B58; fill: #749B58;' />
-<polygon points='602.74,152.93 600.66,156.54 604.82,156.54 ' style='stroke-width: 0.71; stroke: #F0E685; fill: #F0E685;' />
+<polygon points='77.23,331.67 75.15,335.28 79.31,335.28 ' style='stroke-width: 0.71; stroke: #749B58; fill: #749B58;' />
+<polygon points='604.69,152.78 600.79,152.78 600.79,156.68 604.69,156.68 ' style='stroke-width: 0.71; stroke: #F0E685; fill: #F0E685;' />
 <polygon points='329.11,204.67 331.19,201.06 327.02,201.06 ' style='stroke-width: 0.71; stroke: #466983; fill: #466983;' />
-<polygon points='80.51,241.14 78.50,242.60 79.27,244.96 81.75,244.96 82.52,242.60 ' style='stroke-width: 0.71; stroke: #BA6338; fill: #BA6338;' />
-<polygon points='363.25,114.53 361.43,115.58 361.43,117.67 363.25,118.72 365.06,117.67 365.06,115.58 ' style='stroke-width: 0.71; stroke: #5DB1DD; fill: #5DB1DD;' />
-<polygon points='417.49,239.88 416.99,241.31 415.48,241.34 416.68,242.25 416.24,243.70 417.49,242.83 418.73,243.70 418.29,242.25 419.49,241.34 417.98,241.31 ' style='stroke-width: 0.71; stroke: #802268; fill: #802268;' />
-<line x1='380.39' y1='407.55' x2='384.30' y2='407.55' style='stroke-width: 1.57; stroke: #6BD76B; stroke-linecap: butt;' />
-<line x1='382.35' y1='409.51' x2='382.35' y2='405.59' style='stroke-width: 1.57; stroke: #6BD76B; stroke-linecap: butt;' />
-<line x1='189.90' y1='229.66' x2='193.81' y2='225.75' style='stroke-width: 1.57; stroke: #D595A7; stroke-linecap: butt;' />
-<line x1='189.90' y1='225.75' x2='193.81' y2='229.66' style='stroke-width: 1.57; stroke: #D595A7; stroke-linecap: butt;' />
+<line x1='78.55' y1='245.21' x2='82.46' y2='241.30' style='stroke-width: 1.57; stroke: #BA6338; stroke-linecap: butt;' />
+<line x1='78.55' y1='241.30' x2='82.46' y2='245.21' style='stroke-width: 1.57; stroke: #BA6338; stroke-linecap: butt;' />
+<line x1='361.29' y1='116.62' x2='365.20' y2='116.62' style='stroke-width: 1.57; stroke: #5DB1DD; stroke-linecap: butt;' />
+<line x1='363.25' y1='118.58' x2='363.25' y2='114.67' style='stroke-width: 1.57; stroke: #5DB1DD; stroke-linecap: butt;' />
+<line x1='417.49' y1='243.95' x2='417.49' y2='240.03' style='stroke-width: 1.57; stroke: #802268; stroke-linecap: butt;' />
+<line x1='419.18' y1='242.97' x2='415.79' y2='241.01' style='stroke-width: 1.57; stroke: #802268; stroke-linecap: butt;' />
+<line x1='419.18' y1='241.01' x2='415.79' y2='242.97' style='stroke-width: 1.57; stroke: #802268; stroke-linecap: butt;' />
+<polygon points='382.35,405.44 381.85,406.87 380.34,406.90 381.54,407.81 381.11,409.26 382.35,408.39 383.59,409.26 383.15,407.81 384.36,406.90 382.84,406.87 ' style='stroke-width: 0.71; stroke: #6BD76B; fill: #6BD76B;' />
+<polygon points='191.86,225.59 189.85,227.05 190.62,229.42 193.10,229.42 193.87,227.05 ' style='stroke-width: 0.71; stroke: #D595A7; fill: #D595A7;' />
 <rect x='50.96' y='22.90' width='578.06' height='518.09' style='stroke-width: 1.07; stroke: #333333;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
@@ -98,23 +100,25 @@
 <rect x='639.98' y='260.77' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <polygon points='650.57,269.41 648.62,267.45 646.66,269.41 648.62,271.36 ' style='stroke-width: 0.71; stroke: #CE3D32; fill: #CE3D32;' />
 <rect x='639.98' y='278.05' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polygon points='650.57,284.74 646.67,284.74 646.67,288.64 650.57,288.64 ' style='stroke-width: 0.71; stroke: #749B58; fill: #749B58;' />
+<polygon points='648.62,284.88 646.53,288.49 650.70,288.49 ' style='stroke-width: 0.71; stroke: #749B58; fill: #749B58;' />
 <rect x='639.98' y='295.33' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polygon points='648.62,302.16 646.53,305.77 650.70,305.77 ' style='stroke-width: 0.71; stroke: #F0E685; fill: #F0E685;' />
+<polygon points='650.57,302.02 646.67,302.02 646.67,305.92 650.57,305.92 ' style='stroke-width: 0.71; stroke: #F0E685; fill: #F0E685;' />
 <rect x='639.98' y='312.61' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
 <polygon points='648.62,323.05 650.70,319.44 646.53,319.44 ' style='stroke-width: 0.71; stroke: #466983; fill: #466983;' />
 <rect x='639.98' y='329.89' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polygon points='648.62,336.41 646.61,337.87 647.37,340.23 649.86,340.23 650.62,337.87 ' style='stroke-width: 0.71; stroke: #BA6338; fill: #BA6338;' />
+<line x1='646.66' y1='340.48' x2='650.57' y2='336.57' style='stroke-width: 1.57; stroke: #BA6338; stroke-linecap: butt;' />
+<line x1='646.66' y1='336.57' x2='650.57' y2='340.48' style='stroke-width: 1.57; stroke: #BA6338; stroke-linecap: butt;' />
 <rect x='639.98' y='347.17' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polygon points='648.62,353.71 646.80,354.76 646.80,356.85 648.62,357.90 650.43,356.85 650.43,354.76 ' style='stroke-width: 0.71; stroke: #5DB1DD; fill: #5DB1DD;' />
+<line x1='646.66' y1='355.81' x2='650.57' y2='355.81' style='stroke-width: 1.57; stroke: #5DB1DD; stroke-linecap: butt;' />
+<line x1='648.62' y1='357.76' x2='648.62' y2='353.85' style='stroke-width: 1.57; stroke: #5DB1DD; stroke-linecap: butt;' />
 <rect x='639.98' y='364.45' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<polygon points='648.62,370.97 648.12,372.40 646.61,372.43 647.81,373.35 647.37,374.79 648.62,373.93 649.86,374.79 649.42,373.35 650.62,372.43 649.11,372.40 ' style='stroke-width: 0.71; stroke: #802268; fill: #802268;' />
+<line x1='648.62' y1='375.04' x2='648.62' y2='371.13' style='stroke-width: 1.57; stroke: #802268; stroke-linecap: butt;' />
+<line x1='650.31' y1='374.06' x2='646.92' y2='372.11' style='stroke-width: 1.57; stroke: #802268; stroke-linecap: butt;' />
+<line x1='650.31' y1='372.11' x2='646.92' y2='374.06' style='stroke-width: 1.57; stroke: #802268; stroke-linecap: butt;' />
 <rect x='639.98' y='381.73' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='646.66' y1='390.37' x2='650.57' y2='390.37' style='stroke-width: 1.57; stroke: #6BD76B; stroke-linecap: butt;' />
-<line x1='648.62' y1='392.32' x2='648.62' y2='388.41' style='stroke-width: 1.57; stroke: #6BD76B; stroke-linecap: butt;' />
+<polygon points='648.62,388.25 648.12,389.68 646.61,389.71 647.81,390.63 647.37,392.07 648.62,391.21 649.86,392.07 649.42,390.63 650.62,389.71 649.11,389.68 ' style='stroke-width: 0.71; stroke: #6BD76B; fill: #6BD76B;' />
 <rect x='639.98' y='399.01' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
-<line x1='646.66' y1='409.60' x2='650.57' y2='405.69' style='stroke-width: 1.57; stroke: #D595A7; stroke-linecap: butt;' />
-<line x1='646.66' y1='405.69' x2='650.57' y2='409.60' style='stroke-width: 1.57; stroke: #D595A7; stroke-linecap: butt;' />
+<polygon points='648.62,405.53 646.61,406.99 647.37,409.35 649.86,409.35 650.62,406.99 ' style='stroke-width: 0.71; stroke: #D595A7; fill: #D595A7;' />
 <text x='662.73' y='255.15' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
 <text x='662.73' y='272.43' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
 <text x='662.73' y='289.71' style='font-size: 8.80px; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>

--- a/tests/testthat/_snaps/utilities_shapes/all-osp-shapes.svg
+++ b/tests/testthat/_snaps/utilities_shapes/all-osp-shapes.svg
@@ -37,52 +37,52 @@
 <g clip-path='url(#cpNS40OHw3MTQuNTJ8ODMuOTR8NTA5LjM2)'>
 <polygon points='44.23,103.28 44.20,102.64 44.10,102.01 43.95,101.38 43.73,100.78 43.46,100.20 43.13,99.66 42.75,99.14 42.32,98.67 41.84,98.24 41.33,97.86 40.78,97.53 40.20,97.25 39.60,97.04 38.98,96.88 38.35,96.79 37.71,96.76 37.07,96.79 36.44,96.88 35.82,97.04 35.21,97.25 34.64,97.53 34.09,97.86 33.57,98.24 33.10,98.67 32.67,99.14 32.29,99.66 31.96,100.20 31.69,100.78 31.47,101.38 31.31,102.01 31.22,102.64 31.19,103.28 31.22,103.92 31.31,104.55 31.47,105.17 31.69,105.77 31.96,106.35 32.29,106.90 32.67,107.41 33.10,107.89 33.57,108.32 34.09,108.70 34.64,109.03 35.21,109.30 35.82,109.52 36.44,109.67 37.07,109.77 37.71,109.80 38.35,109.77 38.98,109.67 39.60,109.52 40.20,109.30 40.78,109.03 41.33,108.70 41.84,108.32 42.32,107.89 42.75,107.41 43.13,106.90 43.46,106.35 43.73,105.77 43.95,105.17 44.10,104.55 44.20,103.92 ' style='stroke-width: 1.42; fill: #000000;' />
 <polygon points='173.14,103.28 166.63,96.76 160.11,103.28 166.63,109.80 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='302.04,96.78 289.04,96.78 289.04,109.78 302.04,109.78 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='424.46,97.26 417.51,109.29 431.40,109.29 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='295.54,97.26 288.60,109.29 302.49,109.29 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='430.96,96.78 417.96,96.78 417.96,109.78 430.96,109.78 ' style='stroke-width: 1.42; fill: #000000;' />
 <polygon points='553.37,109.29 560.32,97.26 546.43,97.26 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='682.29,96.24 675.59,101.10 678.15,108.97 686.43,108.97 688.99,101.10 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='37.71,225.22 31.67,228.71 31.67,235.68 37.71,239.17 43.75,235.68 43.75,228.71 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='166.63,225.15 164.97,229.92 159.93,230.02 163.95,233.06 162.49,237.89 166.63,235.01 170.76,237.89 169.30,233.06 173.32,230.02 168.28,229.92 ' style='stroke-width: 1.42; fill: #000000;' />
-<line x1='289.02' y1='232.19' x2='302.06' y2='232.19' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='295.54' y1='238.71' x2='295.54' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='417.94' y1='238.71' x2='430.98' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='417.94' y1='225.67' x2='430.98' y2='238.71' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='553.37' y1='238.71' x2='553.37' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='559.02' y1='235.45' x2='547.73' y2='228.93' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='559.02' y1='228.93' x2='547.73' y2='235.45' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<polygon points='688.81,232.19 688.78,231.55 688.69,230.92 688.53,230.30 688.31,229.70 688.04,229.12 687.71,228.57 687.33,228.06 686.90,227.58 686.43,227.15 685.91,226.77 685.36,226.44 684.79,226.17 684.18,225.95 683.56,225.80 682.93,225.71 682.29,225.67 681.65,225.71 681.02,225.80 680.40,225.95 679.80,226.17 679.22,226.44 678.67,226.77 678.16,227.15 677.68,227.58 677.25,228.06 676.87,228.57 676.54,229.12 676.27,229.70 676.05,230.30 675.90,230.92 675.80,231.55 675.77,232.19 675.80,232.83 675.90,233.47 676.05,234.09 676.27,234.69 676.54,235.27 676.87,235.82 677.25,236.33 677.68,236.80 678.16,237.23 678.67,237.61 679.22,237.94 679.80,238.22 680.40,238.43 681.02,238.59 681.65,238.68 682.29,238.71 682.93,238.68 683.56,238.59 684.18,238.43 684.79,238.22 685.36,237.94 685.91,237.61 686.43,237.23 686.90,236.80 687.33,236.33 687.71,235.82 688.04,235.27 688.31,234.69 688.53,234.09 688.69,233.47 688.78,232.83 ' style='stroke-width: 1.42; fill: none;' />
-<polygon points='44.23,361.11 37.71,354.59 31.19,361.11 37.71,367.63 ' style='stroke-width: 1.42; fill: none;' />
-<polygon points='173.13,354.61 160.12,354.61 160.12,367.61 173.13,367.61 ' style='stroke-width: 1.42; fill: none;' />
-<polygon points='295.54,355.10 288.60,367.12 302.49,367.12 ' style='stroke-width: 1.42; fill: none;' />
-<polygon points='424.46,367.12 431.40,355.10 417.51,355.10 ' style='stroke-width: 1.42; fill: none;' />
-<polygon points='553.37,354.07 546.68,358.93 549.24,366.81 557.51,366.81 560.07,358.93 ' style='stroke-width: 1.42; fill: none;' />
-<polygon points='682.29,354.13 676.25,357.62 676.25,364.60 682.29,368.09 688.33,364.60 688.33,357.62 ' style='stroke-width: 1.42; fill: none;' />
+<line x1='675.77' y1='109.80' x2='688.81' y2='96.76' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='675.77' y1='96.76' x2='688.81' y2='109.80' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='31.19' y1='232.19' x2='44.23' y2='232.19' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='37.71' y1='238.71' x2='37.71' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='166.63' y1='238.71' x2='166.63' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='172.27' y1='235.45' x2='160.98' y2='228.93' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='172.27' y1='228.93' x2='160.98' y2='235.45' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<polygon points='295.54,225.15 293.89,229.92 288.85,230.02 292.86,233.06 291.40,237.89 295.54,235.01 299.68,237.89 298.22,233.06 302.24,230.02 297.20,229.92 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='424.46,225.15 417.76,230.02 420.32,237.89 428.60,237.89 431.15,230.02 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='553.37,225.22 547.33,228.71 547.33,235.68 553.37,239.17 559.42,235.68 559.42,228.71 ' style='stroke-width: 1.42; fill: #000000;' />
+<line x1='675.77' y1='238.71' x2='688.81' y2='225.67' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<line x1='675.77' y1='225.67' x2='688.81' y2='238.71' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<line x1='31.19' y1='361.11' x2='44.23' y2='361.11' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<line x1='37.71' y1='367.63' x2='37.71' y2='354.59' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<polygon points='173.14,361.11 173.11,360.47 173.02,359.84 172.86,359.22 172.65,358.62 172.38,358.04 172.05,357.49 171.66,356.97 171.24,356.50 170.76,356.07 170.25,355.69 169.70,355.36 169.12,355.09 168.52,354.87 167.90,354.72 167.26,354.62 166.63,354.59 165.99,354.62 165.35,354.72 164.73,354.87 164.13,355.09 163.55,355.36 163.00,355.69 162.49,356.07 162.02,356.50 161.59,356.97 161.20,357.49 160.88,358.04 160.60,358.62 160.39,359.22 160.23,359.84 160.14,360.47 160.11,361.11 160.14,361.75 160.23,362.38 160.39,363.00 160.60,363.61 160.88,364.18 161.20,364.73 161.59,365.25 162.02,365.72 162.49,366.15 163.00,366.53 163.55,366.86 164.13,367.13 164.73,367.35 165.35,367.50 165.99,367.60 166.63,367.63 167.26,367.60 167.90,367.50 168.52,367.35 169.12,367.13 169.70,366.86 170.25,366.53 170.76,366.15 171.24,365.72 171.66,365.25 172.05,364.73 172.38,364.18 172.65,363.61 172.86,363.00 173.02,362.38 173.11,361.75 ' style='stroke-width: 1.42; fill: none;' />
+<polygon points='302.06,361.11 295.54,354.59 289.02,361.11 295.54,367.63 ' style='stroke-width: 1.42; fill: none;' />
+<polygon points='424.46,355.10 417.51,367.12 431.40,367.12 ' style='stroke-width: 1.42; fill: none;' />
+<polygon points='559.88,354.61 546.87,354.61 546.87,367.61 559.88,367.61 ' style='stroke-width: 1.42; fill: none;' />
+<polygon points='682.29,367.12 689.24,355.10 675.35,355.10 ' style='stroke-width: 1.42; fill: none;' />
 <polygon points='37.71,482.99 36.05,487.75 31.01,487.85 35.03,490.90 33.57,495.72 37.71,492.84 41.85,495.72 40.39,490.90 44.41,487.85 39.36,487.75 ' style='stroke-width: 1.42; fill: none;' />
-<line x1='160.11' y1='490.03' x2='173.14' y2='490.03' style='stroke-width: 1.42; stroke-linecap: butt;' />
-<line x1='166.63' y1='496.55' x2='166.63' y2='483.51' style='stroke-width: 1.42; stroke-linecap: butt;' />
-<line x1='289.02' y1='496.55' x2='302.06' y2='483.51' style='stroke-width: 1.42; stroke-linecap: butt;' />
-<line x1='289.02' y1='483.51' x2='302.06' y2='496.55' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<polygon points='166.63,482.99 159.93,487.85 162.49,495.72 170.76,495.72 173.32,487.85 ' style='stroke-width: 1.42; fill: none;' />
+<polygon points='295.54,483.05 289.50,486.54 289.50,493.51 295.54,497.00 301.58,493.51 301.58,486.54 ' style='stroke-width: 1.42; fill: none;' />
 <text x='37.71' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='16.60px' lengthAdjust='spacingAndGlyphs'>circle</text>
 <text x='166.63' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.29px' lengthAdjust='spacingAndGlyphs'>diamond</text>
-<text x='295.54' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='21.75px' lengthAdjust='spacingAndGlyphs'>square</text>
-<text x='424.46' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='23.33px' lengthAdjust='spacingAndGlyphs'>triangle</text>
+<text x='295.54' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='23.33px' lengthAdjust='spacingAndGlyphs'>triangle</text>
+<text x='424.46' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='21.75px' lengthAdjust='spacingAndGlyphs'>square</text>
 <text x='553.37' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='51.01px' lengthAdjust='spacingAndGlyphs'>invertedTriangle</text>
-<text x='682.29' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.67px' lengthAdjust='spacingAndGlyphs'>pentagon</text>
-<text x='37.71' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.30px' lengthAdjust='spacingAndGlyphs'>hexagon</text>
-<text x='166.63' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>star</text>
-<text x='295.54' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='13.05px' lengthAdjust='spacingAndGlyphs'>plus</text>
-<text x='424.46' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.00px' lengthAdjust='spacingAndGlyphs'>cross</text>
-<text x='553.37' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='24.51px' lengthAdjust='spacingAndGlyphs'>asterisk</text>
-<text x='682.29' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='34.01px' lengthAdjust='spacingAndGlyphs'>circleOpen</text>
-<text x='37.71' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.69px' lengthAdjust='spacingAndGlyphs'>diamondOpen</text>
-<text x='166.63' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='39.16px' lengthAdjust='spacingAndGlyphs'>squareOpen</text>
-<text x='295.54' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='40.73px' lengthAdjust='spacingAndGlyphs'>triangleOpen</text>
-<text x='424.46' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='68.41px' lengthAdjust='spacingAndGlyphs'>invertedTriangleOpen</text>
-<text x='553.37' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='47.08px' lengthAdjust='spacingAndGlyphs'>pentagonOpen</text>
-<text x='682.29' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.70px' lengthAdjust='spacingAndGlyphs'>hexagonOpen</text>
+<text x='682.29' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.00px' lengthAdjust='spacingAndGlyphs'>cross</text>
+<text x='37.71' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='13.05px' lengthAdjust='spacingAndGlyphs'>plus</text>
+<text x='166.63' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='24.51px' lengthAdjust='spacingAndGlyphs'>asterisk</text>
+<text x='295.54' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>star</text>
+<text x='424.46' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.67px' lengthAdjust='spacingAndGlyphs'>pentagon</text>
+<text x='553.37' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.30px' lengthAdjust='spacingAndGlyphs'>hexagon</text>
+<text x='682.29' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='30.05px' lengthAdjust='spacingAndGlyphs'>thinCross</text>
+<text x='37.71' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='25.31px' lengthAdjust='spacingAndGlyphs'>thinPlus</text>
+<text x='166.63' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='34.01px' lengthAdjust='spacingAndGlyphs'>circleOpen</text>
+<text x='295.54' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.69px' lengthAdjust='spacingAndGlyphs'>diamondOpen</text>
+<text x='424.46' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='40.73px' lengthAdjust='spacingAndGlyphs'>triangleOpen</text>
+<text x='553.37' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='39.16px' lengthAdjust='spacingAndGlyphs'>squareOpen</text>
+<text x='682.29' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='68.41px' lengthAdjust='spacingAndGlyphs'>invertedTriangleOpen</text>
 <text x='37.71' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.27px' lengthAdjust='spacingAndGlyphs'>starOpen</text>
-<text x='166.63' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='25.31px' lengthAdjust='spacingAndGlyphs'>thinPlus</text>
-<text x='295.54' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='30.05px' lengthAdjust='spacingAndGlyphs'>thinCross</text>
+<text x='166.63' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='47.08px' lengthAdjust='spacingAndGlyphs'>pentagonOpen</text>
+<text x='295.54' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.70px' lengthAdjust='spacingAndGlyphs'>hexagonOpen</text>
 <text x='424.46' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.01px' lengthAdjust='spacingAndGlyphs'>blank</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/utilities_shapes/osp-shapes-custom-colors.svg
+++ b/tests/testthat/_snaps/utilities_shapes/osp-shapes-custom-colors.svg
@@ -37,52 +37,52 @@
 <g clip-path='url(#cpNS40OHw3MTQuNTJ8ODMuOTR8NTA5LjM2)'>
 <polygon points='44.23,103.28 44.20,102.64 44.10,102.01 43.95,101.38 43.73,100.78 43.46,100.20 43.13,99.66 42.75,99.14 42.32,98.67 41.84,98.24 41.33,97.86 40.78,97.53 40.20,97.25 39.60,97.04 38.98,96.88 38.35,96.79 37.71,96.76 37.07,96.79 36.44,96.88 35.82,97.04 35.21,97.25 34.64,97.53 34.09,97.86 33.57,98.24 33.10,98.67 32.67,99.14 32.29,99.66 31.96,100.20 31.69,100.78 31.47,101.38 31.31,102.01 31.22,102.64 31.19,103.28 31.22,103.92 31.31,104.55 31.47,105.17 31.69,105.77 31.96,106.35 32.29,106.90 32.67,107.41 33.10,107.89 33.57,108.32 34.09,108.70 34.64,109.03 35.21,109.30 35.82,109.52 36.44,109.67 37.07,109.77 37.71,109.80 38.35,109.77 38.98,109.67 39.60,109.52 40.20,109.30 40.78,109.03 41.33,108.70 41.84,108.32 42.32,107.89 42.75,107.41 43.13,106.90 43.46,106.35 43.73,105.77 43.95,105.17 44.10,104.55 44.20,103.92 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
 <polygon points='173.14,103.28 166.63,96.76 160.11,103.28 166.63,109.80 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
-<polygon points='302.04,96.78 289.04,96.78 289.04,109.78 302.04,109.78 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
-<polygon points='424.46,97.26 417.51,109.29 431.40,109.29 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
+<polygon points='295.54,97.26 288.60,109.29 302.49,109.29 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
+<polygon points='430.96,96.78 417.96,96.78 417.96,109.78 430.96,109.78 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
 <polygon points='553.37,109.29 560.32,97.26 546.43,97.26 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
-<polygon points='682.29,96.24 675.59,101.10 678.15,108.97 686.43,108.97 688.99,101.10 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
-<polygon points='37.71,225.22 31.67,228.71 31.67,235.68 37.71,239.17 43.75,235.68 43.75,228.71 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
-<polygon points='166.63,225.15 164.97,229.92 159.93,230.02 163.95,233.06 162.49,237.89 166.63,235.01 170.76,237.89 169.30,233.06 173.32,230.02 168.28,229.92 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
-<line x1='289.02' y1='232.19' x2='302.06' y2='232.19' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='295.54' y1='238.71' x2='295.54' y2='225.67' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='417.94' y1='238.71' x2='430.98' y2='225.67' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='417.94' y1='225.67' x2='430.98' y2='238.71' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='553.37' y1='238.71' x2='553.37' y2='225.67' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='559.02' y1='235.45' x2='547.73' y2='228.93' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='559.02' y1='228.93' x2='547.73' y2='235.45' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
-<polygon points='688.81,232.19 688.78,231.55 688.69,230.92 688.53,230.30 688.31,229.70 688.04,229.12 687.71,228.57 687.33,228.06 686.90,227.58 686.43,227.15 685.91,226.77 685.36,226.44 684.79,226.17 684.18,225.95 683.56,225.80 682.93,225.71 682.29,225.67 681.65,225.71 681.02,225.80 680.40,225.95 679.80,226.17 679.22,226.44 678.67,226.77 678.16,227.15 677.68,227.58 677.25,228.06 676.87,228.57 676.54,229.12 676.27,229.70 676.05,230.30 675.90,230.92 675.80,231.55 675.77,232.19 675.80,232.83 675.90,233.47 676.05,234.09 676.27,234.69 676.54,235.27 676.87,235.82 677.25,236.33 677.68,236.80 678.16,237.23 678.67,237.61 679.22,237.94 679.80,238.22 680.40,238.43 681.02,238.59 681.65,238.68 682.29,238.71 682.93,238.68 683.56,238.59 684.18,238.43 684.79,238.22 685.36,237.94 685.91,237.61 686.43,237.23 686.90,236.80 687.33,236.33 687.71,235.82 688.04,235.27 688.31,234.69 688.53,234.09 688.69,233.47 688.78,232.83 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
-<polygon points='44.23,361.11 37.71,354.59 31.19,361.11 37.71,367.63 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
-<polygon points='173.13,354.61 160.12,354.61 160.12,367.61 173.13,367.61 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
-<polygon points='295.54,355.10 288.60,367.12 302.49,367.12 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
-<polygon points='424.46,367.12 431.40,355.10 417.51,355.10 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
-<polygon points='553.37,354.07 546.68,358.93 549.24,366.81 557.51,366.81 560.07,358.93 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
-<polygon points='682.29,354.13 676.25,357.62 676.25,364.60 682.29,368.09 688.33,364.60 688.33,357.62 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
+<line x1='675.77' y1='109.80' x2='688.81' y2='96.76' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='675.77' y1='96.76' x2='688.81' y2='109.80' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='31.19' y1='232.19' x2='44.23' y2='232.19' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='37.71' y1='238.71' x2='37.71' y2='225.67' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='166.63' y1='238.71' x2='166.63' y2='225.67' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='172.27' y1='235.45' x2='160.98' y2='228.93' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='172.27' y1='228.93' x2='160.98' y2='235.45' style='stroke-width: 3.13; stroke: #B22222; stroke-linecap: butt;' />
+<polygon points='295.54,225.15 293.89,229.92 288.85,230.02 292.86,233.06 291.40,237.89 295.54,235.01 299.68,237.89 298.22,233.06 302.24,230.02 297.20,229.92 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
+<polygon points='424.46,225.15 417.76,230.02 420.32,237.89 428.60,237.89 431.15,230.02 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
+<polygon points='553.37,225.22 547.33,228.71 547.33,235.68 553.37,239.17 559.42,235.68 559.42,228.71 ' style='stroke-width: 1.42; stroke: #B22222; fill: #B22222;' />
+<line x1='675.77' y1='238.71' x2='688.81' y2='225.67' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='675.77' y1='225.67' x2='688.81' y2='238.71' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='31.19' y1='361.11' x2='44.23' y2='361.11' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
+<line x1='37.71' y1='367.63' x2='37.71' y2='354.59' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
+<polygon points='173.14,361.11 173.11,360.47 173.02,359.84 172.86,359.22 172.65,358.62 172.38,358.04 172.05,357.49 171.66,356.97 171.24,356.50 170.76,356.07 170.25,355.69 169.70,355.36 169.12,355.09 168.52,354.87 167.90,354.72 167.26,354.62 166.63,354.59 165.99,354.62 165.35,354.72 164.73,354.87 164.13,355.09 163.55,355.36 163.00,355.69 162.49,356.07 162.02,356.50 161.59,356.97 161.20,357.49 160.88,358.04 160.60,358.62 160.39,359.22 160.23,359.84 160.14,360.47 160.11,361.11 160.14,361.75 160.23,362.38 160.39,363.00 160.60,363.61 160.88,364.18 161.20,364.73 161.59,365.25 162.02,365.72 162.49,366.15 163.00,366.53 163.55,366.86 164.13,367.13 164.73,367.35 165.35,367.50 165.99,367.60 166.63,367.63 167.26,367.60 167.90,367.50 168.52,367.35 169.12,367.13 169.70,366.86 170.25,366.53 170.76,366.15 171.24,365.72 171.66,365.25 172.05,364.73 172.38,364.18 172.65,363.61 172.86,363.00 173.02,362.38 173.11,361.75 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
+<polygon points='302.06,361.11 295.54,354.59 289.02,361.11 295.54,367.63 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
+<polygon points='424.46,355.10 417.51,367.12 431.40,367.12 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
+<polygon points='559.88,354.61 546.87,354.61 546.87,367.61 559.88,367.61 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
+<polygon points='682.29,367.12 689.24,355.10 675.35,355.10 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
 <polygon points='37.71,482.99 36.05,487.75 31.01,487.85 35.03,490.90 33.57,495.72 37.71,492.84 41.85,495.72 40.39,490.90 44.41,487.85 39.36,487.75 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
-<line x1='160.11' y1='490.03' x2='173.14' y2='490.03' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='166.63' y1='496.55' x2='166.63' y2='483.51' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='289.02' y1='496.55' x2='302.06' y2='483.51' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
-<line x1='289.02' y1='483.51' x2='302.06' y2='496.55' style='stroke-width: 1.42; stroke: #B22222; stroke-linecap: butt;' />
+<polygon points='166.63,482.99 159.93,487.85 162.49,495.72 170.76,495.72 173.32,487.85 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
+<polygon points='295.54,483.05 289.50,486.54 289.50,493.51 295.54,497.00 301.58,493.51 301.58,486.54 ' style='stroke-width: 1.42; stroke: #B22222; fill: none;' />
 <text x='37.71' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='16.60px' lengthAdjust='spacingAndGlyphs'>circle</text>
 <text x='166.63' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.29px' lengthAdjust='spacingAndGlyphs'>diamond</text>
-<text x='295.54' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='21.75px' lengthAdjust='spacingAndGlyphs'>square</text>
-<text x='424.46' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='23.33px' lengthAdjust='spacingAndGlyphs'>triangle</text>
+<text x='295.54' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='23.33px' lengthAdjust='spacingAndGlyphs'>triangle</text>
+<text x='424.46' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='21.75px' lengthAdjust='spacingAndGlyphs'>square</text>
 <text x='553.37' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='51.01px' lengthAdjust='spacingAndGlyphs'>invertedTriangle</text>
-<text x='682.29' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.67px' lengthAdjust='spacingAndGlyphs'>pentagon</text>
-<text x='37.71' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.30px' lengthAdjust='spacingAndGlyphs'>hexagon</text>
-<text x='166.63' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>star</text>
-<text x='295.54' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='13.05px' lengthAdjust='spacingAndGlyphs'>plus</text>
-<text x='424.46' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.00px' lengthAdjust='spacingAndGlyphs'>cross</text>
-<text x='553.37' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='24.51px' lengthAdjust='spacingAndGlyphs'>asterisk</text>
-<text x='682.29' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='34.01px' lengthAdjust='spacingAndGlyphs'>circleOpen</text>
-<text x='37.71' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.69px' lengthAdjust='spacingAndGlyphs'>diamondOpen</text>
-<text x='166.63' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='39.16px' lengthAdjust='spacingAndGlyphs'>squareOpen</text>
-<text x='295.54' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='40.73px' lengthAdjust='spacingAndGlyphs'>triangleOpen</text>
-<text x='424.46' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='68.41px' lengthAdjust='spacingAndGlyphs'>invertedTriangleOpen</text>
-<text x='553.37' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='47.08px' lengthAdjust='spacingAndGlyphs'>pentagonOpen</text>
-<text x='682.29' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.70px' lengthAdjust='spacingAndGlyphs'>hexagonOpen</text>
+<text x='682.29' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.00px' lengthAdjust='spacingAndGlyphs'>cross</text>
+<text x='37.71' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='13.05px' lengthAdjust='spacingAndGlyphs'>plus</text>
+<text x='166.63' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='24.51px' lengthAdjust='spacingAndGlyphs'>asterisk</text>
+<text x='295.54' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>star</text>
+<text x='424.46' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.67px' lengthAdjust='spacingAndGlyphs'>pentagon</text>
+<text x='553.37' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.30px' lengthAdjust='spacingAndGlyphs'>hexagon</text>
+<text x='682.29' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='30.05px' lengthAdjust='spacingAndGlyphs'>thinCross</text>
+<text x='37.71' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='25.31px' lengthAdjust='spacingAndGlyphs'>thinPlus</text>
+<text x='166.63' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='34.01px' lengthAdjust='spacingAndGlyphs'>circleOpen</text>
+<text x='295.54' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.69px' lengthAdjust='spacingAndGlyphs'>diamondOpen</text>
+<text x='424.46' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='40.73px' lengthAdjust='spacingAndGlyphs'>triangleOpen</text>
+<text x='553.37' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='39.16px' lengthAdjust='spacingAndGlyphs'>squareOpen</text>
+<text x='682.29' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='68.41px' lengthAdjust='spacingAndGlyphs'>invertedTriangleOpen</text>
 <text x='37.71' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.27px' lengthAdjust='spacingAndGlyphs'>starOpen</text>
-<text x='166.63' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='25.31px' lengthAdjust='spacingAndGlyphs'>thinPlus</text>
-<text x='295.54' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='30.05px' lengthAdjust='spacingAndGlyphs'>thinCross</text>
+<text x='166.63' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='47.08px' lengthAdjust='spacingAndGlyphs'>pentagonOpen</text>
+<text x='295.54' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.70px' lengthAdjust='spacingAndGlyphs'>hexagonOpen</text>
 <text x='424.46' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.01px' lengthAdjust='spacingAndGlyphs'>blank</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>

--- a/tests/testthat/_snaps/utilities_shapes/osp-shapes-with-fill.svg
+++ b/tests/testthat/_snaps/utilities_shapes/osp-shapes-with-fill.svg
@@ -37,52 +37,52 @@
 <g clip-path='url(#cpNS40OHw3MTQuNTJ8ODMuOTR8NTA5LjM2)'>
 <polygon points='44.23,103.28 44.20,102.64 44.10,102.01 43.95,101.38 43.73,100.78 43.46,100.20 43.13,99.66 42.75,99.14 42.32,98.67 41.84,98.24 41.33,97.86 40.78,97.53 40.20,97.25 39.60,97.04 38.98,96.88 38.35,96.79 37.71,96.76 37.07,96.79 36.44,96.88 35.82,97.04 35.21,97.25 34.64,97.53 34.09,97.86 33.57,98.24 33.10,98.67 32.67,99.14 32.29,99.66 31.96,100.20 31.69,100.78 31.47,101.38 31.31,102.01 31.22,102.64 31.19,103.28 31.22,103.92 31.31,104.55 31.47,105.17 31.69,105.77 31.96,106.35 32.29,106.90 32.67,107.41 33.10,107.89 33.57,108.32 34.09,108.70 34.64,109.03 35.21,109.30 35.82,109.52 36.44,109.67 37.07,109.77 37.71,109.80 38.35,109.77 38.98,109.67 39.60,109.52 40.20,109.30 40.78,109.03 41.33,108.70 41.84,108.32 42.32,107.89 42.75,107.41 43.13,106.90 43.46,106.35 43.73,105.77 43.95,105.17 44.10,104.55 44.20,103.92 ' style='stroke-width: 1.42; fill: #000000;' />
 <polygon points='173.14,103.28 166.63,96.76 160.11,103.28 166.63,109.80 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='302.04,96.78 289.04,96.78 289.04,109.78 302.04,109.78 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='424.46,97.26 417.51,109.29 431.40,109.29 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='295.54,97.26 288.60,109.29 302.49,109.29 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='430.96,96.78 417.96,96.78 417.96,109.78 430.96,109.78 ' style='stroke-width: 1.42; fill: #000000;' />
 <polygon points='553.37,109.29 560.32,97.26 546.43,97.26 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='682.29,96.24 675.59,101.10 678.15,108.97 686.43,108.97 688.99,101.10 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='37.71,225.22 31.67,228.71 31.67,235.68 37.71,239.17 43.75,235.68 43.75,228.71 ' style='stroke-width: 1.42; fill: #000000;' />
-<polygon points='166.63,225.15 164.97,229.92 159.93,230.02 163.95,233.06 162.49,237.89 166.63,235.01 170.76,237.89 169.30,233.06 173.32,230.02 168.28,229.92 ' style='stroke-width: 1.42; fill: #000000;' />
-<line x1='289.02' y1='232.19' x2='302.06' y2='232.19' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='295.54' y1='238.71' x2='295.54' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='417.94' y1='238.71' x2='430.98' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='417.94' y1='225.67' x2='430.98' y2='238.71' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='553.37' y1='238.71' x2='553.37' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='559.02' y1='235.45' x2='547.73' y2='228.93' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<line x1='559.02' y1='228.93' x2='547.73' y2='235.45' style='stroke-width: 3.13; stroke-linecap: butt;' />
-<polygon points='688.81,232.19 688.78,231.55 688.69,230.92 688.53,230.30 688.31,229.70 688.04,229.12 687.71,228.57 687.33,228.06 686.90,227.58 686.43,227.15 685.91,226.77 685.36,226.44 684.79,226.17 684.18,225.95 683.56,225.80 682.93,225.71 682.29,225.67 681.65,225.71 681.02,225.80 680.40,225.95 679.80,226.17 679.22,226.44 678.67,226.77 678.16,227.15 677.68,227.58 677.25,228.06 676.87,228.57 676.54,229.12 676.27,229.70 676.05,230.30 675.90,230.92 675.80,231.55 675.77,232.19 675.80,232.83 675.90,233.47 676.05,234.09 676.27,234.69 676.54,235.27 676.87,235.82 677.25,236.33 677.68,236.80 678.16,237.23 678.67,237.61 679.22,237.94 679.80,238.22 680.40,238.43 681.02,238.59 681.65,238.68 682.29,238.71 682.93,238.68 683.56,238.59 684.18,238.43 684.79,238.22 685.36,237.94 685.91,237.61 686.43,237.23 686.90,236.80 687.33,236.33 687.71,235.82 688.04,235.27 688.31,234.69 688.53,234.09 688.69,233.47 688.78,232.83 ' style='stroke-width: 1.42; fill: #4682B4;' />
-<polygon points='44.23,361.11 37.71,354.59 31.19,361.11 37.71,367.63 ' style='stroke-width: 1.42; fill: #4682B4;' />
-<polygon points='173.13,354.61 160.12,354.61 160.12,367.61 173.13,367.61 ' style='stroke-width: 1.42; fill: #4682B4;' />
-<polygon points='295.54,355.10 288.60,367.12 302.49,367.12 ' style='stroke-width: 1.42; fill: #4682B4;' />
-<polygon points='424.46,367.12 431.40,355.10 417.51,355.10 ' style='stroke-width: 1.42; fill: #4682B4;' />
-<polygon points='553.37,354.07 546.68,358.93 549.24,366.81 557.51,366.81 560.07,358.93 ' style='stroke-width: 1.42; fill: #4682B4;' />
-<polygon points='682.29,354.13 676.25,357.62 676.25,364.60 682.29,368.09 688.33,364.60 688.33,357.62 ' style='stroke-width: 1.42; fill: #4682B4;' />
+<line x1='675.77' y1='109.80' x2='688.81' y2='96.76' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='675.77' y1='96.76' x2='688.81' y2='109.80' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='31.19' y1='232.19' x2='44.23' y2='232.19' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='37.71' y1='238.71' x2='37.71' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='166.63' y1='238.71' x2='166.63' y2='225.67' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='172.27' y1='235.45' x2='160.98' y2='228.93' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<line x1='172.27' y1='228.93' x2='160.98' y2='235.45' style='stroke-width: 3.13; stroke-linecap: butt;' />
+<polygon points='295.54,225.15 293.89,229.92 288.85,230.02 292.86,233.06 291.40,237.89 295.54,235.01 299.68,237.89 298.22,233.06 302.24,230.02 297.20,229.92 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='424.46,225.15 417.76,230.02 420.32,237.89 428.60,237.89 431.15,230.02 ' style='stroke-width: 1.42; fill: #000000;' />
+<polygon points='553.37,225.22 547.33,228.71 547.33,235.68 553.37,239.17 559.42,235.68 559.42,228.71 ' style='stroke-width: 1.42; fill: #000000;' />
+<line x1='675.77' y1='238.71' x2='688.81' y2='225.67' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<line x1='675.77' y1='225.67' x2='688.81' y2='238.71' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<line x1='31.19' y1='361.11' x2='44.23' y2='361.11' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<line x1='37.71' y1='367.63' x2='37.71' y2='354.59' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<polygon points='173.14,361.11 173.11,360.47 173.02,359.84 172.86,359.22 172.65,358.62 172.38,358.04 172.05,357.49 171.66,356.97 171.24,356.50 170.76,356.07 170.25,355.69 169.70,355.36 169.12,355.09 168.52,354.87 167.90,354.72 167.26,354.62 166.63,354.59 165.99,354.62 165.35,354.72 164.73,354.87 164.13,355.09 163.55,355.36 163.00,355.69 162.49,356.07 162.02,356.50 161.59,356.97 161.20,357.49 160.88,358.04 160.60,358.62 160.39,359.22 160.23,359.84 160.14,360.47 160.11,361.11 160.14,361.75 160.23,362.38 160.39,363.00 160.60,363.61 160.88,364.18 161.20,364.73 161.59,365.25 162.02,365.72 162.49,366.15 163.00,366.53 163.55,366.86 164.13,367.13 164.73,367.35 165.35,367.50 165.99,367.60 166.63,367.63 167.26,367.60 167.90,367.50 168.52,367.35 169.12,367.13 169.70,366.86 170.25,366.53 170.76,366.15 171.24,365.72 171.66,365.25 172.05,364.73 172.38,364.18 172.65,363.61 172.86,363.00 173.02,362.38 173.11,361.75 ' style='stroke-width: 1.42; fill: #4682B4;' />
+<polygon points='302.06,361.11 295.54,354.59 289.02,361.11 295.54,367.63 ' style='stroke-width: 1.42; fill: #4682B4;' />
+<polygon points='424.46,355.10 417.51,367.12 431.40,367.12 ' style='stroke-width: 1.42; fill: #4682B4;' />
+<polygon points='559.88,354.61 546.87,354.61 546.87,367.61 559.88,367.61 ' style='stroke-width: 1.42; fill: #4682B4;' />
+<polygon points='682.29,367.12 689.24,355.10 675.35,355.10 ' style='stroke-width: 1.42; fill: #4682B4;' />
 <polygon points='37.71,482.99 36.05,487.75 31.01,487.85 35.03,490.90 33.57,495.72 37.71,492.84 41.85,495.72 40.39,490.90 44.41,487.85 39.36,487.75 ' style='stroke-width: 1.42; fill: #4682B4;' />
-<line x1='160.11' y1='490.03' x2='173.14' y2='490.03' style='stroke-width: 1.42; stroke-linecap: butt;' />
-<line x1='166.63' y1='496.55' x2='166.63' y2='483.51' style='stroke-width: 1.42; stroke-linecap: butt;' />
-<line x1='289.02' y1='496.55' x2='302.06' y2='483.51' style='stroke-width: 1.42; stroke-linecap: butt;' />
-<line x1='289.02' y1='483.51' x2='302.06' y2='496.55' style='stroke-width: 1.42; stroke-linecap: butt;' />
+<polygon points='166.63,482.99 159.93,487.85 162.49,495.72 170.76,495.72 173.32,487.85 ' style='stroke-width: 1.42; fill: #4682B4;' />
+<polygon points='295.54,483.05 289.50,486.54 289.50,493.51 295.54,497.00 301.58,493.51 301.58,486.54 ' style='stroke-width: 1.42; fill: #4682B4;' />
 <text x='37.71' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='16.60px' lengthAdjust='spacingAndGlyphs'>circle</text>
 <text x='166.63' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.29px' lengthAdjust='spacingAndGlyphs'>diamond</text>
-<text x='295.54' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='21.75px' lengthAdjust='spacingAndGlyphs'>square</text>
-<text x='424.46' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='23.33px' lengthAdjust='spacingAndGlyphs'>triangle</text>
+<text x='295.54' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='23.33px' lengthAdjust='spacingAndGlyphs'>triangle</text>
+<text x='424.46' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='21.75px' lengthAdjust='spacingAndGlyphs'>square</text>
 <text x='553.37' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='51.01px' lengthAdjust='spacingAndGlyphs'>invertedTriangle</text>
-<text x='682.29' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.67px' lengthAdjust='spacingAndGlyphs'>pentagon</text>
-<text x='37.71' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.30px' lengthAdjust='spacingAndGlyphs'>hexagon</text>
-<text x='166.63' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>star</text>
-<text x='295.54' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='13.05px' lengthAdjust='spacingAndGlyphs'>plus</text>
-<text x='424.46' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.00px' lengthAdjust='spacingAndGlyphs'>cross</text>
-<text x='553.37' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='24.51px' lengthAdjust='spacingAndGlyphs'>asterisk</text>
-<text x='682.29' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='34.01px' lengthAdjust='spacingAndGlyphs'>circleOpen</text>
-<text x='37.71' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.69px' lengthAdjust='spacingAndGlyphs'>diamondOpen</text>
-<text x='166.63' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='39.16px' lengthAdjust='spacingAndGlyphs'>squareOpen</text>
-<text x='295.54' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='40.73px' lengthAdjust='spacingAndGlyphs'>triangleOpen</text>
-<text x='424.46' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='68.41px' lengthAdjust='spacingAndGlyphs'>invertedTriangleOpen</text>
-<text x='553.37' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='47.08px' lengthAdjust='spacingAndGlyphs'>pentagonOpen</text>
-<text x='682.29' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.70px' lengthAdjust='spacingAndGlyphs'>hexagonOpen</text>
+<text x='682.29' y='122.86' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.00px' lengthAdjust='spacingAndGlyphs'>cross</text>
+<text x='37.71' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='13.05px' lengthAdjust='spacingAndGlyphs'>plus</text>
+<text x='166.63' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='24.51px' lengthAdjust='spacingAndGlyphs'>asterisk</text>
+<text x='295.54' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='11.86px' lengthAdjust='spacingAndGlyphs'>star</text>
+<text x='424.46' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.67px' lengthAdjust='spacingAndGlyphs'>pentagon</text>
+<text x='553.37' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='27.30px' lengthAdjust='spacingAndGlyphs'>hexagon</text>
+<text x='682.29' y='251.77' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='30.05px' lengthAdjust='spacingAndGlyphs'>thinCross</text>
+<text x='37.71' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='25.31px' lengthAdjust='spacingAndGlyphs'>thinPlus</text>
+<text x='166.63' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='34.01px' lengthAdjust='spacingAndGlyphs'>circleOpen</text>
+<text x='295.54' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.69px' lengthAdjust='spacingAndGlyphs'>diamondOpen</text>
+<text x='424.46' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='40.73px' lengthAdjust='spacingAndGlyphs'>triangleOpen</text>
+<text x='553.37' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='39.16px' lengthAdjust='spacingAndGlyphs'>squareOpen</text>
+<text x='682.29' y='380.69' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='68.41px' lengthAdjust='spacingAndGlyphs'>invertedTriangleOpen</text>
 <text x='37.71' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='29.27px' lengthAdjust='spacingAndGlyphs'>starOpen</text>
-<text x='166.63' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='25.31px' lengthAdjust='spacingAndGlyphs'>thinPlus</text>
-<text x='295.54' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='30.05px' lengthAdjust='spacingAndGlyphs'>thinCross</text>
+<text x='166.63' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='47.08px' lengthAdjust='spacingAndGlyphs'>pentagonOpen</text>
+<text x='295.54' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='44.70px' lengthAdjust='spacingAndGlyphs'>hexagonOpen</text>
 <text x='424.46' y='509.61' text-anchor='middle' style='font-size: 7.11px; font-family: sans;' textLength='17.01px' lengthAdjust='spacingAndGlyphs'>blank</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>


### PR DESCRIPTION
+ Places harder-to-distinguish thin variants (thinCross, thinPlus) after filled shapes but before open shapes.
+ testthat::snapshot_accept()

To reduce side effects on ospsuiteR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the order of available shapes used for automatic shape assignment and recycling
  * Added `thinCross` and `thinPlus` shapes to the available shape selection options
  * Reorganized open-shape entries in the shape list
  * Code formatting improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->