### PR TITLE
Increment version number to 1.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ospsuite.plots
 Type: Package
 Title: Library for standardized graphs
-Version: 1.2.0.9005
-Authors@R: 
+Version: 1.3.0
+Authors@R:
     c(person(given = "Open-Systems-Pharmacology Community",
              role = "cph"),
       person(given = "Katrin",
@@ -14,10 +14,10 @@ Description: This library provides a standardized approach to creating graphs an
 URL: https://www.open-systems-pharmacology.org/OSPSuite.Plots/
 License: GPL-2 | file LICENSE
 Language: en-US
-Depends: 
+Depends:
     R (>= 4.1.0),
     ggplot2 (>= 4.0)
-Imports: 
+Imports:
     checkmate,
     cowplot,
     data.table,
@@ -82,7 +82,7 @@ Collate: 'messages.R'
          'utilities_export.R'
          'utilities_shapes.R'
 LazyData: true
-Remotes: 
-    ospsuite.utils=Open-Systems-Pharmacology/OSPSuite.RUtils
+Remotes:
+    ospsuite.utils=Open-Systems-Pharmacology/OSPSuite.RUtils@*release
 Config/roxygen2/version: 8.0.0
 RoxygenNote: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ospsuite.plots (development version)
+# ospsuite.plots 1.3.0
 
 ## New Features
 


### PR DESCRIPTION
release needed for OSPSuiteR as it requires ospsuite.plots 1.2.0.9003 +

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Release**
  * Released `ospsuite.plots` version 1.3.0.
  * Updated package metadata to reflect the stable release.

* **Documentation**
  * Updated the release notes to identify version 1.3.0 instead of the development version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->