### PR TITLE
Resolve OSP dependencies through the r-universe

### DIFF
--- a/.github/workflows/codecov-nightly.yml
+++ b/.github/workflows/codecov-nightly.yml
@@ -11,5 +11,7 @@ permissions: read-all
 jobs:
   test-coverage:
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: https://open-systems-pharmacology.r-universe.dev
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -22,6 +22,8 @@ jobs:
     if: ${{ !cancelled() }}
     permissions: read-all
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-build.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
 
   pkgdown:
     needs: bump-dev-version

--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -29,4 +29,6 @@ jobs:
     needs: bump-dev-version
     if: ${{ !cancelled() }}
     uses:  Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,6 +82,7 @@ Collate: 'messages.R'
          'utilities_export.R'
          'utilities_shapes.R'
 LazyData: true
+Additional_repositories: https://open-systems-pharmacology.r-universe.dev
 Remotes:
     ospsuite.utils=Open-Systems-Pharmacology/OSPSuite.RUtils
 Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,7 +83,5 @@ Collate: 'messages.R'
          'utilities_shapes.R'
 LazyData: true
 Additional_repositories: https://open-systems-pharmacology.r-universe.dev
-Remotes:
-    ospsuite.utils=Open-Systems-Pharmacology/OSPSuite.RUtils
 Config/roxygen2/version: 8.0.0
 RoxygenNote: 8.0.0

--- a/README.md
+++ b/README.md
@@ -44,25 +44,6 @@ To install the development version from GitHub instead, use
 pak::pak("Open-Systems-Pharmacology/OSPSuite.Plots")
 ```
 
-`{ospsuite.plots}` requires the following packages, which the commands above
-install for you:
-
-From CRAN:
-
-- [ggplot2](https://cran.r-project.org/package=ggplot2/index.html)
-- [ggh4x](https://cran.r-project.org/package=ggh4x/index.html)
-- [cowplot](https://cran.r-project.org/package=cowplot/index.html)
-- [data.table](https://cran.r-project.org/package=data.table/index.html)
-- [ggnewscale](https://cran.r-project.org/package=ggnewscale/index.html)
-- [checkmate](https://cran.r-project.org/package=checkmate/index.html)
-- [dplyr](https://cran.r-project.org/package=dplyr/index.html)
-- [tidyr](https://cran.r-project.org/package=tidyr/index.html)
-- [fs](https://cran.r-project.org/package=fs/index.html)
-
-From the OSP R-universe:
-
--   [ospsuite.utils](https://open-systems-pharmacology.r-universe.dev/ospsuite.utils)
-
 ## Code of conduct
 
 Everyone interacting in the Open Systems Pharmacology community (codebases,

--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ To install the development version from GitHub instead, use
 pak::pak("Open-Systems-Pharmacology/OSPSuite.Plots")
 ```
 
-Binaries also remain attached to every
-[GitHub release](https://github.com/Open-Systems-Pharmacology/OSPSuite.Plots/releases),
-and can be installed from a local file with
-`install.packages(pathToZip, repos = NULL)`.
-
 `{ospsuite.plots}` requires the following packages, which the commands above
 install for you:
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,33 @@ This is the beta release of the  `{ospsuite.plots}`. We welcome your feedback as
 
 ## Installation
 
-You can install the development version of `{ospsuite.plots}` from
-[GitHub](https://github.com/) with:
+`{ospsuite.plots}` and its Open Systems Pharmacology dependencies are published
+on the [OSP R-universe](https://open-systems-pharmacology.r-universe.dev).
+Installing the released version needs nothing but base R, and resolves
+`{ospsuite.utils}` for you:
 
 ``` r
-# install.packages("remotes")
-remotes::install_github("Open-Systems-Pharmacology/ospsuite.plots")
+install.packages(
+  "ospsuite.plots",
+  repos = c(OSP = "https://open-systems-pharmacology.r-universe.dev", getOption("repos"))
+)
 ```
 
-`{ospsuite.plots}` requires following packages to be installed:
+To install the development version from GitHub instead, use
+[pak](https://pak.r-lib.org):
+
+``` r
+# install.packages("pak")
+pak::pak("Open-Systems-Pharmacology/OSPSuite.Plots")
+```
+
+Binaries also remain attached to every
+[GitHub release](https://github.com/Open-Systems-Pharmacology/OSPSuite.Plots/releases),
+and can be installed from a local file with
+`install.packages(pathToZip, repos = NULL)`.
+
+`{ospsuite.plots}` requires the following packages, which the commands above
+install for you:
 
 From CRAN:
 
@@ -46,30 +64,9 @@ From CRAN:
 - [tidyr](https://cran.r-project.org/package=tidyr/index.html)
 - [fs](https://cran.r-project.org/package=fs/index.html)
 
-Must be downloaded manually:
+From the OSP R-universe:
 
--   [ospsuite.utils](https://github.com/Open-Systems-Pharmacology/OSPSuite.RUtils/releases/download/v1.3.17/ospsuite.utils_1.3.17.zip)
-
-
-To install manually, follow these instructions:
-
-```r
-# Install `{ospsuite.utils}` from local file 
-# (`pathTo_ospsuite.utils.zip` here should be replaced with the actual path to the `.zip` file)
-install.packages(pathTo_ospsuite.utils.zip, repos = NULL)
-
-
-# Install dependencies (e.g. ggplot2) which are on CRAN
-install.packages('ggplot2')
-install.packages('ggh4x')
-install.packages('data.table')
-install.packages('ggnewscale')
-install.packages('checkmate')
-install.packages('dplyr')
-install.packages('tidyr')
-install.packages('fs')
-
-```
+-   [ospsuite.utils](https://open-systems-pharmacology.r-universe.dev/ospsuite.utils)
 
 ## Code of conduct
 


### PR DESCRIPTION
Makes the OSP R-universe the resolution channel for `ospsuite.plots`, in CI and for source installs, and retires the OSP-to-OSP `Remotes:` chain for this package. `ospsuite.plots` imports `ospsuite.utils`, which is not on CRAN, so resolution previously went through `Remotes:` and the GitHub API, which forced a from-source build and depended on multi-layer GitHub API resolution. Every workflow on this branch is green with the universe as the only source for that dependency, on Linux, Windows and macOS.

## CI

Add `extra-repositories: https://open-systems-pharmacology.r-universe.dev` to every job that installs the package or its dependencies, so the universe is on `getOption("repos")`:

- `main-workflow.yaml`: the `R-CMD-Check` and `pkgdown` jobs, passed as an input to the reusable workflows, which forward it to `setup-r-env` and on to `r-lib/actions/setup-r`.
- `codecov-nightly.yml`: the `test-coverage` job, same mechanism.
- `lint.yaml`: on `r-lib/actions/setup-r` directly, since that job is hand-rolled rather than a reusable-workflow caller.

The `pkgdown`, `test-coverage` and `update-renv-lockfile` inputs come from Workflows#249; the `R-CMD-check-build` one already existed.

## DESCRIPTION

- Declare `Additional_repositories: https://open-systems-pharmacology.r-universe.dev`, so `R CMD check` can validate the non-CRAN dependency and source installs (`install.packages(dependencies = TRUE)`, `remotes::install_local()` on a tarball) can find `ospsuite.utils` without pak.
- Drop the `Remotes:` entry for `ospsuite.utils`. This is the change that actually switches the channel, and it is worth being explicit about why, because the additive steps alone do nothing. Measured on this branch: with `Remotes:` present and the universe already on `repos`, pak ignored the universe and fetched `ospsuite.utils 1.11.1.9001` as a GitHub zipball, building it from source. With the field removed it resolves `ospsuite.utils 1.11.1` from `https://open-systems-pharmacology.r-universe.dev/src/contrib/`. `Imports` already required `>= 1.4.0`, which the universe release satisfies, so no version floor change was needed.

Order matters within this PR: removing `Remotes:` before wiring up `pkgdown`, `test-coverage` and `lint` broke each of those jobs with `Can't find package called ospsuite.utils`, since `Remotes:` had been their only route to it. Anyone replicating this on another OSP package should audit every workflow that installs the package, not only the ones calling reusable workflows.

## README

Rewrite the installation section around the universe. The released version now installs with plain base R and no extra tooling:

```r
install.packages(
  "ospsuite.plots",
  repos = c(OSP = "https://open-systems-pharmacology.r-universe.dev", getOption("repos"))
)
```

The development version keeps a documented path via `pak::pak("Open-Systems-Pharmacology/OSPSuite.Plots")`. The instructions for installing a downloaded binary are removed: `install.packages()` ignores `dependencies` when `repos = NULL`, so that path can never resolve dependencies on its own, and the old text handled this with a hand-maintained list of `install.packages()` calls plus a link to `ospsuite.utils_1.3.17.zip`, a version that no longer satisfies this package's own `Imports` floor. Since the universe serves binaries for Windows and macOS, the command above covers what that section was for.

This covers the CI and `DESCRIPTION` steps plus the `Remotes:` retirement from the plan tracked in the R-universe registry issue "Wire OSP dependency resolution through R-universe": https://github.com/Open-Systems-Pharmacology/open-systems-pharmacology.r-universe.dev/issues/2
