### PR TITLE
Fix the development install instruction for universe resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,17 @@ install.packages(
 ```
 
 To install the development version from GitHub instead, use
-[pak](https://pak.r-lib.org):
+[pak](https://pak.r-lib.org). The universe still has to be on `repos` for this:
+the development sources declare their OSP dependencies without saying where
+to find them, and pak does not read `Additional_repositories`.
 
 ``` r
 # install.packages("pak")
+options(repos = c(
+  OSP = "https://open-systems-pharmacology.r-universe.dev",
+  getOption("repos")
+))
+
 pak::pak("Open-Systems-Pharmacology/OSPSuite.Plots")
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ This is the beta release of the  `{ospsuite.plots}`. We welcome your feedback as
 
 ## Installation
 
-`{ospsuite.plots}` and its Open Systems Pharmacology dependencies are published
-on the [OSP R-universe](https://open-systems-pharmacology.r-universe.dev).
-Installing the released version needs nothing but base R, and resolves
-`{ospsuite.utils}` for you:
+Install the released version from the [OSP
+R-universe](https://open-systems-pharmacology.r-universe.dev):
 
 ``` r
 install.packages(
@@ -37,9 +35,7 @@ install.packages(
 ```
 
 To install the development version from GitHub instead, use
-[pak](https://pak.r-lib.org). The universe still has to be on `repos` for this:
-the development sources declare their OSP dependencies without saying where
-to find them, and pak does not read `Additional_repositories`.
+[pak](https://pak.r-lib.org):
 
 ``` r
 # install.packages("pak")


### PR DESCRIPTION
Fixes the development-version install instruction in the README, which cannot work as written since the OSP-to-OSP `Remotes:` chain was retired.

`pak::pak("Open-Systems-Pharmacology/OSPSuite.Plots")` resolves the GitHub sources, reads their `DESCRIPTION`, and then has to find `ospsuite.utils`. With `Remotes:` gone there is nothing telling pak where that package lives, and pak does not read `Additional_repositories`, so with default repositories the resolution fails outright. Putting the universe on `repos` first is what makes the documented command work.

Verified with pak's resolver against the current sources:

```
default repos (CRAN only):  FAIL   error in pak subprocess
with the universe on repos: OK     ospsuite.utils resolved: 1.11.1 via standard
```

## README

- Set `options(repos = c(OSP = "https://open-systems-pharmacology.r-universe.dev", getOption("repos")))` before the `pak::pak()` call, and say why it is needed.

The released-version instruction above it was already correct, because it passes `repos` as an argument to `install.packages()`.

Same fix is needed on every package in the stack whose `Remotes:` field has been retired. It is being applied to `tlf` and `ospsuite` as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to include the released package available through the OSP R-universe.
  * Added R repository configuration guidance for installing the development version with `pak`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->